### PR TITLE
[ELY-2346] Update HashPasswordSpec to make use of MessageDigest#isEqual to avoid a potential timing attack

### DIFF
--- a/credential/base/src/main/java/org/wildfly/security/password/spec/HashPasswordSpec.java
+++ b/credential/base/src/main/java/org/wildfly/security/password/spec/HashPasswordSpec.java
@@ -52,7 +52,7 @@ public final class HashPasswordSpec implements PasswordSpec {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof HashPasswordSpec && Arrays.equals(digest, ((HashPasswordSpec)other).digest);
+        return other instanceof HashPasswordSpec && MessageDigest.equals(digest, ((HashPasswordSpec)other).digest);
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2436
